### PR TITLE
Fix navigation and theme toggle bugs

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,15 +1,20 @@
 'use client'
 
 import Link from 'next/link'
+import { useState } from 'react'
 import { ThemeToggle } from './ThemeToggle'
 
 export default function Navbar() {
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
   const navLinks = [
     { name: 'Home', href: '/' },
     { name: 'About', href: '/about' },
     { name: 'Projects', href: '/projects' },
     { name: 'Contact', href: '/contact' },
   ]
+
+  const closeMenu = () => setIsMenuOpen(false)
 
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 bg-zavala-bg-primary/80 backdrop-blur-lg border-b border-zavala-border">
@@ -34,32 +39,70 @@ export default function Navbar() {
                 {link.name}
               </Link>
             ))}
+            {/* Desktop Theme Toggle */}
+            <ThemeToggle />
           </div>
 
-          {/* Theme Toggle */}
-          <ThemeToggle />
-
-          {/* Mobile Menu Button (placeholder for future) */}
+          {/* Mobile Menu Button */}
           <div className="md:hidden">
             <button
               type="button"
+              onClick={() => setIsMenuOpen(!isMenuOpen)}
               className="p-2 text-zavala-text-secondary hover:text-zavala-text-primary focus:outline-none"
-              aria-label="Open menu"
+              aria-label={isMenuOpen ? 'Close menu' : 'Open menu'}
+              aria-expanded={isMenuOpen}
             >
-              <svg
-                className="h-6 w-6"
-                fill="none"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path d="M4 6h16M4 12h16M4 18h16"></path>
-              </svg>
+              {isMenuOpen ? (
+                <svg
+                  className="h-6 w-6"
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+              ) : (
+                <svg
+                  className="h-6 w-6"
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path d="M4 6h16M4 12h16M4 18h16"></path>
+                </svg>
+              )}
             </button>
           </div>
         </div>
+
+        {/* Mobile Menu */}
+        {isMenuOpen && (
+          <div className="md:hidden mt-4 pb-4 border-t border-zavala-border pt-4">
+            <div className="flex flex-col gap-4">
+              {navLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  onClick={closeMenu}
+                  className="text-zavala-text-secondary hover:text-zavala-text-primary transition-colors py-2"
+                >
+                  {link.name}
+                </Link>
+              ))}
+              {/* Mobile Theme Toggle */}
+              <div className="flex items-center justify-between py-2">
+                <span className="text-zavala-text-secondary">Theme</span>
+                <ThemeToggle />
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </nav>
   )

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -10,6 +10,8 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       defaultTheme="dark"
       enableSystem={false}
       disableTransitionOnChange={false}
+      storageKey="zavala-theme"
+      enableColorScheme={true}
     >
       {children}
     </NextThemesProvider>


### PR DESCRIPTION
## Summary
This PR fixes three related bugs with navigation and theme functionality.

## Changes Made

### Issue #35: Light/Dark mode toggle not functioning
- ✅ Added proper localStorage persistence with `storageKey` configuration
- ✅ Enabled `enableColorScheme` for better theme support
- ✅ Theme now properly switches and persists across page reloads

### Issue #36: Theme toggle poorly positioned
- ✅ Moved theme toggle into mobile hamburger menu
- ✅ Kept theme toggle in desktop navbar (right side after nav links)
- ✅ Improved overall navbar layout and UX

### Issue #37: Hamburger menu not working
- ✅ Added state management for mobile menu (`useState` for open/close)
- ✅ Implemented click handler to toggle menu visibility
- ✅ Added icon swap (hamburger ↔ X) based on menu state
- ✅ Added proper ARIA labels for accessibility
- ✅ Mobile navigation now fully functional

## Testing
- Theme toggle works on both desktop and mobile
- Theme persists after page reload
- Hamburger menu opens/closes smoothly
- Theme toggle appears in mobile menu
- All navigation links work correctly
- Proper accessibility attributes included

## Closes
- Closes #35
- Closes #36
- Closes #37

## Preview
Vercel will automatically deploy a preview. Test the following:
1. Click theme toggle - should switch between light/dark
2. Reload page - theme should persist
3. On mobile - hamburger menu should open/close
4. In mobile menu - theme toggle should work