### PR TITLE
Final tweaks: Resume spacing and homepage button clarity

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -11,21 +11,21 @@ export default function AboutPage() {
     <div className="min-h-screen">
       {/* Hero Section */}
       <section className="max-w-4xl mx-auto px-6 py-16 md:py-24">
-        <div className="mb-16">
+        <div className="mb-12">
           {/* Name & Tagline */}
           <h1 className="text-4xl md:text-5xl font-bold mb-4 text-zavala-text-primary">
             Maximiliano Zavala
           </h1>
-          <p className="text-xl text-zavala-accent-primary font-medium mb-8">
+          <p className="text-xl text-zavala-accent-primary font-medium mb-4">
             Software Engineer | AI Enthusiast
           </p>
         </div>
       </section>
 
       {/* Resume Section */}
-      <section className="bg-zavala-bg-surface border-t border-b border-zavala-border py-16 md:py-24">
+      <section className="bg-zavala-bg-surface border-t border-b border-zavala-border py-12 md:py-16">
         <div className="max-w-4xl mx-auto px-6">
-          <h2 className="text-3xl md:text-4xl font-bold mb-12 text-zavala-text-primary">
+          <h2 className="text-3xl md:text-4xl font-bold mb-10 text-zavala-text-primary">
             Resume
           </h2>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -99,7 +99,7 @@ export default function Home() {
             <div className="text-center">
               <Link href="/about">
                 <Button variant="secondary" size="lg">
-                  Learn More About Me
+                  View My Resume
                 </Button>
               </Link>
             </div>


### PR DESCRIPTION
## Changes

**Issue #69: Reduce Resume page spacing**
- Reduced spacing below tagline (mb-8 → mb-4)
- Reduced hero section bottom margin (mb-16 → mb-12)
- Reduced Resume section padding (py-16/24 → py-12/16)
- Result: Tighter, more professional layout

**Issue #70: Update homepage button text**
- Changed 'Learn More About Me' to 'View My Resume'
- Makes it clear the button links to the Resume page

## Testing
- ✅ Visual spacing improvements on Resume page
- ✅ Button text is clear and actionable

Closes #69
Closes #70